### PR TITLE
Next release

### DIFF
--- a/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/QmomKinetics.cpp
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/QmomKinetics.cpp
@@ -202,6 +202,7 @@ void QmomKinetics( const state_type &y , state_type &dydt , double t )
             break;
         case 3:
             // set input vector
+            modena_inputs_set(inputs_kinetics, kineticTime_Pos, t);
             modena_inputs_set(inputs_kinetics, Catalyst_1_Pos, Catalyst_1);
             modena_inputs_set(inputs_kinetics, CE_A0_Pos, CE_A0);
             modena_inputs_set(inputs_kinetics, CE_A1_Pos, CE_A1);

--- a/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/modenaCalls.h
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/modenaCalls.h
@@ -85,6 +85,7 @@ inputs_thermalConductivity = modena_inputs_new (thermalConductivitymodel);
 outputs_thermalConductivity = modena_outputs_new (thermalConductivitymodel);
 
 // inputs argPos
+kineticTime_Pos  = modena_model_inputs_argPos(kinetics, "'kineticTime'");
 Catalyst_1_Pos   = modena_model_inputs_argPos(kinetics, "'Catalyst_1'");
 CE_A0_Pos        = modena_model_inputs_argPos(kinetics, "'CE_A0'");
 CE_A1_Pos        = modena_model_inputs_argPos(kinetics, "'CE_A1'");

--- a/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/modenaData.h
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_0D/src/modenaData.h
@@ -38,6 +38,7 @@ modena_outputs_t *outputs_strutContent;
 modena_inputs_t *inputs_thermalConductivity;
 modena_outputs_t *outputs_thermalConductivity;
 
+size_t kineticTime_Pos;
 size_t Catalyst_1_Pos;
 size_t CE_A0_Pos;
 size_t CE_A1_Pos;

--- a/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/conversionSources.H
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/conversionSources.H
@@ -140,6 +140,7 @@ if (KineticsModel == "RF-1")
 {
     forAll(mesh.C(), celli)
     {
+        modena_inputs_set(inputs_kinetics, kineticTime_Pos, runTime.value());
         modena_inputs_set(inputs_kinetics, Catalyst_1_Pos, (Catalyst_1[celli]));
         modena_inputs_set(inputs_kinetics, CE_A0_Pos, (CE_A0[celli]));
         modena_inputs_set(inputs_kinetics, CE_A1_Pos, (CE_A1[celli]));

--- a/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/modenaCalls.h
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/modenaCalls.h
@@ -66,6 +66,7 @@ outputs_strutContent = modena_outputs_new (strutContentmodel);
 inputs_thermalConductivity = modena_inputs_new (thermalConductivitymodel);
 outputs_thermalConductivity = modena_outputs_new (thermalConductivitymodel);
 
+kineticTime_Pos = modena_model_inputs_argPos(kinetics, "'kineticTime'");
 Catalyst_1_Pos = modena_model_inputs_argPos(kinetics, "'Catalyst_1'");
 CE_A0_Pos = modena_model_inputs_argPos(kinetics, "'CE_A0'");
 CE_A1_Pos = modena_model_inputs_argPos(kinetics, "'CE_A1'");

--- a/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/modenaData.h
+++ b/applications/PUfoam/MoDeNaModels/CFD_tool_3D/src/modenaData.h
@@ -33,6 +33,7 @@ modena_outputs_t *outputs_strutContent;
 modena_inputs_t *inputs_thermalConductivity;
 modena_outputs_t *outputs_thermalConductivity;
 
+size_t kineticTime_Pos ;
 size_t Catalyst_1_Pos ;
 size_t CE_A0_Pos;
 size_t CE_A1_Pos;

--- a/applications/PUfoam/MoDeNaModels/Kinetics/predici_2_modena.py
+++ b/applications/PUfoam/MoDeNaModels/Kinetics/predici_2_modena.py
@@ -618,8 +618,9 @@ void predici_kinetics
     double *outputs
 )
 {
-    double time = 0.0;
-    FandA((double *) inputs, time, outputs);
+    double time = inputs[0];
+    double * inputParams = (double *) (&(inputs[1]));
+    FandA(inputParams, time, outputs);
 }
 '''
 
@@ -636,6 +637,7 @@ void predici_kinetics
     for index in range(len(namelist)):
         namelist[index] = namelist[index].replace('"',"'")
 
+    namelist.insert(0,"'kineticTime'");
     returnDict = {}
     returnDict['Ccode'] = codestring
     returnDict['inputs'] = {}
@@ -644,7 +646,8 @@ void predici_kinetics
 
     for index in range(len(namelist)):
         returnDict['inputs'][namelist[index]] = \
-            {'min': 0, 'max': 9e99, 'argPos': index}
+            {'min': -10, 'max': 9e99, 'argPos': index}
+    namelist.pop(0);
 
     # ------------ Extract output list --------------------
 

--- a/applications/PUfoam/MoDeNaModels/Rheology/Rheology.py
+++ b/applications/PUfoam/MoDeNaModels/Rheology/Rheology.py
@@ -36,6 +36,7 @@ License
 """
 
 import os
+import json
 import modena
 import SurfaceTension
 import polymerViscosity 

--- a/applications/PUfoam/MoDeNaModels/bubbleGrowth/src/src/model.f90
+++ b/applications/PUfoam/MoDeNaModels/bubbleGrowth/src/src/model.f90
@@ -265,10 +265,11 @@ subroutine kinModel(y)
     integer :: i
     if (kin_model==4) then
         do i=1,size(kineq)
-            call modena_inputs_set(kinInputs, kinInputsPos(i), y(kineq(i)))
+            call modena_inputs_set(kinInputs, kinInputsPos(i+1), y(kineq(i)))
         enddo
     endif
-    call modena_inputs_set(kinInputs, kinInputsPos(19), y(teq)-273.15_dp)
+    call modena_inputs_set(kinInputs, kinInputsPos(1), time)
+    call modena_inputs_set(kinInputs, kinInputsPos(20), y(teq)-273.15_dp)
     ret = modena_model_call (kinModena, kinInputs, kinOutputs)
     if(ret /= 0) then
         call exit(ret)

--- a/applications/PUfoam/MoDeNaModels/bubbleGrowth/src/src/modenastuff.f90
+++ b/applications/PUfoam/MoDeNaModels/bubbleGrowth/src/src/modenastuff.f90
@@ -16,7 +16,7 @@ module modenastuff
         itensTPos,&
         diffTPos(2),&
         solTPos(2),solXgasPos(2),solXmdiPos(2),solXpolyolPos(2),&
-        kinInputsPos(20),kinOutputsPos(20)
+        kinInputsPos(21),kinOutputsPos(20)
     type(c_ptr) :: &
         viscModena = c_null_ptr,&
         viscInputs = c_null_ptr,&
@@ -204,44 +204,46 @@ subroutine createModenaModels
         kinInputs = modena_inputs_new (kinModena);
         kinOutputs = modena_outputs_new (kinModena);
         kinInputsPos(1) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'Catalyst_1'"//c_null_char);
+            c_char_"'kineticTime'"//c_null_char);
         kinInputsPos(2) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_A0'"//c_null_char);
+            c_char_"'Catalyst_1'"//c_null_char);
         kinInputsPos(3) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_A1'"//c_null_char);
+            c_char_"'CE_A0'"//c_null_char);
         kinInputsPos(4) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_B'"//c_null_char);
+            c_char_"'CE_A1'"//c_null_char);
         kinInputsPos(5) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_B2'"//c_null_char);
+            c_char_"'CE_B'"//c_null_char);
         kinInputsPos(6) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_I0'"//c_null_char);
+            c_char_"'CE_B2'"//c_null_char);
         kinInputsPos(7) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_I1'"//c_null_char);
+            c_char_"'CE_I0'"//c_null_char);
         kinInputsPos(8) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_I2'"//c_null_char);
+            c_char_"'CE_I1'"//c_null_char);
         kinInputsPos(9) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_PBA'"//c_null_char);
+            c_char_"'CE_I2'"//c_null_char);
         kinInputsPos(10) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Breac'"//c_null_char);
+            c_char_"'CE_PBA'"//c_null_char);
         kinInputsPos(11) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Areac0'"//c_null_char);
+            c_char_"'CE_Breac'"//c_null_char);
         kinInputsPos(12) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Areac1'"//c_null_char);
+            c_char_"'CE_Areac0'"//c_null_char);
         kinInputsPos(13) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Ireac0'"//c_null_char);
+            c_char_"'CE_Areac1'"//c_null_char);
         kinInputsPos(14) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Ireac1'"//c_null_char);
+            c_char_"'CE_Ireac0'"//c_null_char);
         kinInputsPos(15) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'CE_Ireac2'"//c_null_char);
+            c_char_"'CE_Ireac1'"//c_null_char);
         kinInputsPos(16) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'Bulk'"//c_null_char);
+            c_char_"'CE_Ireac2'"//c_null_char);
         kinInputsPos(17) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'R_1'"//c_null_char);
+            c_char_"'Bulk'"//c_null_char);
         kinInputsPos(18) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'R_1_mass'"//c_null_char);
+            c_char_"'R_1'"//c_null_char);
         kinInputsPos(19) = modena_model_inputs_argPos(kinModena, &
-            c_char_"'R_1_temp'"//c_null_char);
+            c_char_"'R_1_mass'"//c_null_char);
         kinInputsPos(20) = modena_model_inputs_argPos(kinModena, &
+            c_char_"'R_1_temp'"//c_null_char);
+        kinInputsPos(21) = modena_model_inputs_argPos(kinModena, &
             c_char_"'R_1_vol'"//c_null_char);
         kinOutputsPos(1) = modena_model_outputs_argPos(kinModena, &
             c_char_"source_Catalyst_1"//c_null_char);


### PR DESCRIPTION
adding current time as input parameter for kinetics module.
Incorporated necessary changes in CFD_tool_0D, CFD_tool_3D, and bubblegrowth.
Pavel: we noticed one line where you relied on the indexing of the kinetics parameters (temperature) and we corrected it from 19 to now 20. 
We are not aware of any other critical lines of code. 
