### PR TITLE
CMake bump, type conversion error and example fixes.

### DIFF
--- a/examples/MoDeNaModels/flowRate/flowRate.py
+++ b/examples/MoDeNaModels/flowRate/flowRate.py
@@ -35,10 +35,8 @@ License
 @ingroup   twoTank
 """
 
-from . import DETAILED_MODEL_PATH, DETAILED_MODEL_EXEC
-
 from os import system
-from os.path import join
+from os.path import abspath, dirname, join
 
 import modena
 from modena import ForwardMappingModel, BackwardMappingModel, SurrogateModel, CFunction, ModenaFireTask
@@ -70,7 +68,7 @@ class FlowRateExactSim(ModenaFireTask):
         # In this simple example, this call stands for a complex microscopic
         # code - such as full 3D CFD simulation.
         # Source code in src/flowRateExact.C
-        ret = system(join(DETAILED_MODEL_PATH, DETAILED_MODEL_EXEC))
+        ret = system(join(abspath(dirname(__file__)),'src','flowRateExact'))
 
         # This enables backward mapping capabilities (not needed in this example)
         self.handleReturnCode(ret)
@@ -79,10 +77,6 @@ class FlowRateExactSim(ModenaFireTask):
         f = open('out.txt', 'r')
         self['point']['flowRate'] = float(f.readline())
         f.close()
-
-
-
-
 
 
 f = CFunction(

--- a/examples/MoDeNaModels/flowRate/flowRate.py
+++ b/examples/MoDeNaModels/flowRate/flowRate.py
@@ -35,7 +35,11 @@ License
 @ingroup   twoTank
 """
 
-import os
+from . import DETAILED_MODEL_PATH, DETAILED_MODEL_EXEC
+
+from os import system
+from os.path import join
+
 import modena
 from modena import ForwardMappingModel, BackwardMappingModel, SurrogateModel, CFunction, ModenaFireTask
 import modena.Strategy as Strategy
@@ -54,7 +58,6 @@ class FlowRateExactSim(ModenaFireTask):
 
     def task(self, fw_spec):
         # Write input
-
         # See http://jinja.pocoo.org/docs/dev/templates/
         Template('''
 {{ s['point']['D'] }}
@@ -67,7 +70,7 @@ class FlowRateExactSim(ModenaFireTask):
         # In this simple example, this call stands for a complex microscopic
         # code - such as full 3D CFD simulation.
         # Source code in src/flowRateExact.C
-        ret = os.system(os.path.dirname(os.path.abspath(__file__))+'/src/flowRateExact')
+        ret = system(join(DETAILED_MODEL_PATH, DETAILED_MODEL_EXEC))
 
         # This enables backward mapping capabilities (not needed in this example)
         self.handleReturnCode(ret)
@@ -121,31 +124,6 @@ void two_tank_flowRate
 )
 
 
-import rpy2.rinterface as rinterface
-from rpy2.robjects.packages import importr
-from numpy import array
-from numpy.random import normal
-
-rinterface.initr()
-lhs = importr('lhs')
-
-
-class TemporaryClass(modena.Strategy.StochasticSampling):
-
-    def samplePoints(self, model, sr, nPoints):
-        """
-        """
-        sampleRange = { k: {'min': min(model.fitData[k]) , 'max': max(model.fitData[k]) } for k in model.inputs.keys() }
-
-        points = array(lhs.randomLHS(nPoints, len(model.inputs))).tolist()
-        points[0] = [ normal(0.5, p) for p in point[0] ]
-        points[1] = [ normal(0.5, p) for p in point[1] ]
-
-        return { key: [ sr[key]['min'] + (sr[key]['min'] - sr[key]['min'])*points[j][i] for j in xrange(nPoints) ] for (i, key) in enumerate(sr) }
-
-
-
-
 
 m = BackwardMappingModel(
     _id= 'flowRate',
@@ -164,10 +142,10 @@ m = BackwardMappingModel(
     outOfBoundsStrategy= Strategy.ExtendSpaceStochasticSampling(
         nNewPoints= 4
     ),
-    parameterFittingStrategy= Strategy.Test(
+    parameterFittingStrategy= Strategy. NonLinFitWithErrorContol(
         testDataPercentage= 0.2,
         maxError= 0.5,
-        improveErrorStrategy= TemporaryClass(
+        improveErrorStrategy= Strategy. NonLinFitWithErrorContol(
             nNewPoints= 2,
             constraints = "p0 / p1 > 0"
         ),

--- a/examples/MoDeNaModels/twoTank/src/twoTanksMacroscopicProblem.C
+++ b/examples/MoDeNaModels/twoTank/src/twoTanksMacroscopicProblem.C
@@ -79,21 +79,21 @@ main(int argc, char *argv[])
     modena_outputs_t *outputs = modena_outputs_new(model);
 
     cout << "inputs:" << endl;
-    char** iNames = modena_model_inputs_names(model);
+    const char** iNames = modena_model_inputs_names(model);
     for(int i=0; i<modena_model_inputs_size(model); i++)
     {
         cout << iNames[i] << endl;
     }
 
     cout << "outputs:" << endl;
-    char** oNames = modena_model_outputs_names(model);
+    const char** oNames = modena_model_outputs_names(model);
     for(int i=0; i<modena_model_outputs_size(model); i++)
     {
         cout << oNames[i] << endl;
     }
 
     cout << "parameters:" << endl;
-    char** pNames = modena_model_parameters_names(model);
+    const char** pNames = modena_model_parameters_names(model);
     for(int i=0; i<modena_model_parameters_size(model); i++)
     {
         cout << pNames[i] << endl;

--- a/examples/MoDeNaModels/twoTank/twoTank.py
+++ b/examples/MoDeNaModels/twoTank/twoTank.py
@@ -36,9 +36,9 @@ License
 """
 
 from modena.Strategy import BackwardMappingScriptTask
-import os
+from os.path import abspath, dirname, join
 
 # Source code in src/twoTanksMacroscopicProblem.C
 m = BackwardMappingScriptTask(
-    script=os.path.dirname(os.path.abspath(__file__))+'/src/twoTanksMacroscopicProblem'
+    script=join(dirname(abspath(__file__)),'src','twoTanksMacroscopicProblem')
 )

--- a/examples/MoDeNaModels/twoTankCxx/src/twoTanksMacroscopicProblemCxx.C
+++ b/examples/MoDeNaModels/twoTankCxx/src/twoTanksMacroscopicProblemCxx.C
@@ -111,7 +111,8 @@ main(int argc, char *argv[])
                 model.inputs_set(p1Byp0Pos, p1/p0);
 
                 // Call the model
-                model.call();
+                // auto model(inputs);
+                model();
 
                 // Fetch result
                 double mdot = model.outputs_get(0);
@@ -128,7 +129,7 @@ main(int argc, char *argv[])
                 model.inputs_set(p1Byp0Pos, p0/p1);
 
                 // Call the model
-                model.call();
+                model();
 
                 // Fetch result
                 double mdot = model.outputs_get(0);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,17 +1,22 @@
-cmake_minimum_required (VERSION 2.8)
-project (modena C CXX Fortran)
+cmake_minimum_required (VERSION 3.0)
+project (modena VERSION 1.0 LANGUAGES C CXX Fortran)
 
-if( CMAKE_VERSION VERSION_GREATER "3.0" )
-    cmake_policy(SET CMP0042 OLD)
-    cmake_policy(SET CMP0026 OLD)
-    cmake_policy(SET CMP0028 OLD)
-endif()
+message("*************************************************")
+message("-- MoDeNa Version: ${PROJECT_VERSION}")
+message("-- MoDeNa Build Dir: ${CMAKE_CURRENT_BINARY_DIR}")
+message("-- MoDeNa Install Prefix: ${CMAKE_INSTALL_PREFIX}")
+message("*************************************************")
+
+
+# Outlaw "in-source" build -------------------------------------------------- #
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 
-set(PACKAGE_VERSION 1.0)
+# Build Types --------------------------------------------------------------- #
 
 set(CMAKE_BUILD_TYPE Debug)
 
@@ -27,9 +32,25 @@ add_custom_target(release
   COMMENT "Switch CMAKE_BUILD_TYPE to Release"
   )
 
+# Standardise Install Locations --------------------------------------------- #
+set(INSTALL_LIB_DIR     lib     CACHE PATH "Library install directories")
+set(INSTALL_BIN_DIR     bin     CACHE PATH "Executables install directories")
+set(INSTALL_INCLUDE_DIR include CACHE PATH "Header files install directory")
+
+foreach(p LIB BIN INCLUDE CMAKE)                 # Make relative paths absolute
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
+
+# --------------------------------------------------------------------------- #
+
 set(MODENA_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+# Locate Libraries ---------------------------------------------------------- #
 
 include(CheckCInline)
 check_c_inline(C_INLINE)
@@ -38,6 +59,7 @@ find_package(LTDL REQUIRED)
 
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
+
 
 include_directories(src)
 

--- a/src/src/CMakeLists.txt
+++ b/src/src/CMakeLists.txt
@@ -1,8 +1,14 @@
 # Build C library
 
+
+# Obtain Headers and Sources ------------------------------------------------ #
+
 file(GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h ${CMAKE_CURRENT_SOURCE_DIR}/*.H)
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
+# Build Libraries ----------------------------------------------------------- #
+
+# --> C
 add_library(modena SHARED ${SOURCES})
 target_link_libraries(modena ${LTDL_LIBRARIES} ${PYTHON_LIBRARIES})
 
@@ -22,15 +28,16 @@ set_property(
 )
 set_target_properties(modena PROPERTIES PUBLIC_HEADER "${HEADERS}")
 
-# Build Fortran library
+# --> FORTRAN
 add_library(fmodena SHARED fmodena.f90)
 target_link_libraries(fmodena ${LTDL_LIBRARIES} ${PYTHON_LIBRARIES})
 
 # Build executables
 add_executable(twoTanksFullProblem twoTanksFullProblem.C)
 
-# Build configuration files
-configure_file(libmodena.pc.in libmodena.pc @ONLY)
+# Build configuration files ------------------------------------------------- #
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmodena.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/libmodena.pc" @ONLY)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -51,30 +58,32 @@ configure_file(
   COPYONLY
 )
 
-# Installation
+# Installation -------------------------------------------------------------- #
 if(CMAKE_VERSION VERSION_GREATER "2.8.12")
   install(
     TARGETS twoTanksFullProblem modena fmodena
     EXPORT MODENATargets
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib/modena
-    ARCHIVE DESTINATION lib/static
-    PUBLIC_HEADER DESTINATION include/modena
-    INCLUDES DESTINATION include/modena
+    RUNTIME DESTINATION ${INSTALL_BIN_DIR}
+    LIBRARY DESTINATION ${INSTALL_LIB_DIR}/modena
+    ARCHIVE DESTINATION ${INSTALL_LIB_DIR}/static
+    PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}/modena
+    INCLUDES DESTINATION ${INSTALL_INCLUDE_DIR}/modena
   )
 else()
   install(
     TARGETS twoTanksFullProblem modena fmodena
     EXPORT MODENATargets
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib/modena
-    ARCHIVE DESTINATION lib/static
-    PUBLIC_HEADER DESTINATION include/modena
+    RUNTIME DESTINATION ${INSTALL_BIN_DIR}
+    LIBRARY DESTINATION ${INSTALL_LIB_DIR}/modena
+    ARCHIVE DESTINATION ${INSTALL_LIB_DIR}/static
+    PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}/modena
   )
 endif()
 
-install(FILES libmodena.pc DESTINATION lib/pkgconfig)
-install(FILES fmodena.mod DESTINATION include/modena)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libmodena.pc"
+        DESTINATION "${INSTALL_LIB_DIR}/pkgconfig")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/fmodena.mod"
+        DESTINATION "${INSTALL_INCLUDE_DIR}/modena")
 
 install(
   EXPORT MODENATargets

--- a/src/src/model.c
+++ b/src/src/model.c
@@ -431,17 +431,17 @@ void modena_model_argPos_check(const modena_model_t *self)
     }
 }
 
-char** modena_model_inputs_names(const modena_model_t *self)
+const char** modena_model_inputs_names(const modena_model_t *self)
 {
     return self->inputs_names;
 }
 
-char** modena_model_outputs_names(const modena_model_t *self)
+const char** modena_model_outputs_names(const modena_model_t *self)
 {
     return self->outputs_names;
 }
 
-char** modena_model_parameters_names(const modena_model_t *self)
+const char** modena_model_parameters_names(const modena_model_t *self)
 {
     return self->parameters_names;
 }
@@ -690,19 +690,19 @@ void modena_model_destroy(modena_model_t *self)
 
     for(i = 0; i < self->inputs_size; i++)
     {
-        free(self->inputs_names[i]);
+        free((char*)self->inputs_names[i]);
     }
     free(self->inputs_names);
 
     for(i = 0; i < self->outputs_size; i++)
     {
-        free(self->outputs_names[i]);
+        free((char*)self->outputs_names[i]);
     }
     free(self->outputs_names);
 
     for(i = 0; i < self->parameters_size; i++)
     {
-        free(self->parameters_names[i]);
+        free((char*)self->parameters_names[i]);
     }
     free(self->parameters_names);
 
@@ -859,9 +859,11 @@ static PyObject *modena_model_t_call
  * -------   -----------  ----------------------------------------------------
  * ml_name   char *       name of the method
  * ml_meth   PyCFunction  pointer to the C implementation
- * ml_flags  int          flag bits indicating how the call should be
- *                        constructed
+ * ml_flags  int          flag bits indicating how the call is constructed
  * ml_doc    char *       points to the contents of the docstring
+ *
+ *
+ * [online doc]: https://docs.python.org/2/c-api/structures.html#c.PyMethodDef
  */
 static PyMethodDef modena_model_t_methods[] = {
     {"call", (PyCFunction) modena_model_t_call, METH_KEYWORDS,
@@ -870,7 +872,7 @@ static PyMethodDef modena_model_t_methods[] = {
     {NULL}  /* Sentinel */
 };
 
-/*
+/**
  */
 PyObject*
 modena_model_t_get_parameters(modena_model_t *self, void *closure)
@@ -884,7 +886,7 @@ modena_model_t_get_parameters(modena_model_t *self, void *closure)
     return pParams;
 }
 
-/*
+/**
  */
 static int
 modena_model_t_set_parameters(modena_model_t *self, PyObject *value, void *closure)
@@ -994,7 +996,7 @@ static int modena_model_t_init
         Py_INCREF(pModel);
         self->pModel = pModel;
     }
-    
+
     //PyObject_Print(self->pModel, stdout, 0);
     //printf("\n");
 
@@ -1144,6 +1146,13 @@ static PyObject * modena_model_t_new
     return (PyObject *)self;
 }
 
+/**
+ * @brief  Documentation of modena_model_t class
+*/
+PyDoc_STRVAR(module_doc,
+ "modena_model_t objects\n"
+);
+
 /* C-Python: The C structure used to describe the modena_model type.
  */
 PyTypeObject modena_model_tType = {
@@ -1168,7 +1177,7 @@ PyTypeObject modena_model_tType = {
     0,                                                          /*tp_setattro*/
     0,                                                         /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,                      /*tp_flags*/
-    "modena_model_t objects",                                      /* tp_doc */
+    module_doc,                                                    /* tp_doc */
     0,                                                        /* tp_traverse */
     0,                                                           /* tp_clear */
     0,                                                     /* tp_richcompare */

--- a/src/src/model.h
+++ b/src/src/model.h
@@ -126,9 +126,9 @@ typedef struct modena_model_t
 
     modena_substitute_model_t *substituteModels; /**< Substitute models `modena_substitute_model_t`*/
 
-    char** inputs_names;                /**< Surrogate model inputs names */
-    char** outputs_names;               /**< Surrogate model outputs names */
-    char** parameters_names;            /**< Surrogate model parameter names */
+    const char** inputs_names;                /**< Surrogate model inputs names */
+    const char** outputs_names;               /**< Surrogate model outputs names */
+    const char** parameters_names;            /**< Surrogate model parameter names */
 
 } modena_model_t;
 
@@ -306,7 +306,7 @@ size_t modena_model_outputs_argPos
  *
  *  @param self pointer to surrogate model created by modena_model_new.
 */
-char** modena_model_inputs_names
+const char** modena_model_inputs_names
 (
     const modena_model_t *self
 );
@@ -318,7 +318,7 @@ char** modena_model_inputs_names
  *
  *  @param self pointer to surrogate model created by modena_model_new.
 */
-char** modena_model_outputs_names
+const char** modena_model_outputs_names
 (
     const modena_model_t *self
 );
@@ -330,7 +330,7 @@ char** modena_model_outputs_names
  *
  *  @param self pointer to surrogate model created by modena_model_new.
 */
-char** modena_model_parameters_names
+const char** modena_model_parameters_names
 (
     const modena_model_t *self
 );

--- a/src/src/modenaModel.H
+++ b/src/src/modenaModel.H
@@ -79,143 +79,199 @@ public:
     }
 };
 
-
+/**
+ * @brief    C++ wrapper class for MoDeNa Models
+ * @author   Henrik Rusche
+ * @date     2016
+ * @details
+ *           The class
+ *
+*/
 class modenaModel
 {
-    // Private data
 
+private :
         // Pointer to MoDeNa model
         modena_model_t *model_;
 
         modena_inputs_t *inputs_;
         modena_outputs_t *outputs_;
 
-public:
- 
+public :
+
     // Constructors
 
-        //- Construct from model name
-        modenaModel
-        (
-            const std::string& name
-        )
-        {
-            // Instantiate a model
-            model_ = modena_model_new(name.c_str());
-
-            if(modena_error_occurred())
-            {
-                throw modenaException(modena_error());
-            }
-
-            // Allocate memory and fetch arg positions
-            inputs_ = modena_inputs_new(model_);
-            outputs_ = modena_outputs_new(model_);
-        }
+        modenaModel(const std::string& name); //- Construct from model name
 
     // Destructor
 
-        ~modenaModel()
-        {
-            modena_inputs_destroy(inputs_);
-            modena_outputs_destroy(outputs_);
-            modena_model_destroy(model_);
-        }
+        ~modenaModel();
 
-    // Member Functions
+    // Overloaded Operators
 
-        inline size_t inputs_size() const
-        {
-            return modena_model_inputs_size(model_);
-        }
+        // Subscript
+        double& operator[](const size_t& idx);
+        const double& operator [](const size_t& idx) const;
 
-        inline size_t outputs_size() const
-        {
-            return modena_model_outputs_size(model_);
-        }
+        void operator()(void);
 
-        inline size_t parameters_size() const
-        {
-            return modena_model_parameters_size(model_);
-        }
+    // Member Functions (inline is technically redundant in declaration)
 
-        inline size_t inputs_argPos(const std::string& name) const
-        {
-            return modena_model_inputs_argPos(model_, name.c_str());
-        }
+        inline size_t inputs_size() const;
+        inline size_t outputs_size() const;
+        inline size_t parameters_size() const;
 
-        inline size_t outputs_argPos(const std::string& name) const
-        {
-            return modena_model_outputs_argPos(model_, name.c_str());
-        }
+        inline size_t inputs_argPos(const std::string& name) const;
+        inline size_t outputs_argPos(const std::string& name) const;
 
-        inline void inputs_set(const size_t i, double x) const
-        {
-            modena_inputs_set(inputs_, i, x);
-        }
+        inline void inputs_set(const size_t i, double x) const;
 
-        inline double outputs_get(const size_t i) const
-        {
-           return modena_outputs_get(outputs_, i);
-        }
+        inline double inputs_get(const size_t i) const;
+        inline double outputs_get(const size_t i) const;
 
-        inline void argPos_check() const
-        {
-            modena_model_argPos_check(model_);
-        }
+        inline void argPos_check() const;
+        inline void call() const;
 
-        inline std::vector<std::string> inputs_names() const
-        {
-            std::vector<std::string> v;
-
-            const char** iNames = modena_model_inputs_names(model_);
-            for(int i=0; i<modena_model_inputs_size(model_); i++)
-            {
-                v.push_back(std::string(iNames[i]));
-            }
-
-            return v;
-        }
-
-        inline std::vector<std::string> outputs_names() const
-        {
-            std::vector<std::string> v;
-
-            const char** oNames = modena_model_outputs_names(model_);
-            for(int i=0; i<modena_model_outputs_size(model_); i++)
-            {
-                v.push_back(std::string(oNames[i]));
-            }
-
-            return v;
-        }
-
-        inline std::vector<std::string> parameters_names() const
-        {
-            std::vector<std::string> v;
-
-            const char** pNames = modena_model_parameters_names(model_);
-            for(int i=0; i<modena_model_parameters_size(model_); i++)
-            {
-                v.push_back(std::string(pNames[i]));
-            }
-
-            return v;
-        }
-
-        inline void call() const
-        {
-            modena_model_call(model_, inputs_, outputs_);
-
-            if(modena_error_occurred())
-            {
-                throw modenaException(modena_error());
-            }
-        }
-
+        inline std::vector<std::string> inputs_names() const;
+        inline std::vector<std::string> outputs_names() const;
+        inline std::vector<std::string> parameters_names() const;
 };
 
+//- Construct from model name
+modenaModel::modenaModel(const std::string& name)
+{
+    // Instantiate a model
+    model_ = modena_model_new(name.c_str());
+
+    if(modena_error_occurred())
+        throw modenaException(modena_error());
+
+    // Allocate memory and fetch arg positions
+    inputs_ = modena_inputs_new(model_);
+    outputs_ = modena_outputs_new(model_);
+}
+
+/**
+ * @brief  Destructor
+ *
+*/
+modenaModel::~modenaModel()
+{
+    modena_inputs_destroy(inputs_);
+    modena_outputs_destroy(outputs_);
+    modena_model_destroy(model_);
+}
+
+// Operators
+double& modenaModel::operator[](const size_t& idx)
+{
+  std::cout << "Setter" << std::endl;
+  return this->inputs_->inputs[idx];
+}
+
+const double& modenaModel::operator[](const size_t& idx) const
+{
+    const double ret = outputs_get(idx);
+    return ret;
+}
+
+void modenaModel::operator()(void)
+{
+    this->call();
+}
+
+// Member Functions
+
+inline size_t modenaModel::inputs_size() const
+{
+    return modena_model_inputs_size(model_);
+}
+
+inline size_t modenaModel::outputs_size() const
+{
+    return modena_model_outputs_size(model_);
+}
+
+inline size_t modenaModel::parameters_size() const
+{
+    return modena_model_parameters_size(model_);
+}
+
+inline size_t modenaModel::inputs_argPos(const std::string& name) const
+{
+    return modena_model_inputs_argPos(model_, name.c_str());
+}
+
+inline size_t modenaModel::outputs_argPos(const std::string& name) const
+{
+    return modena_model_outputs_argPos(model_, name.c_str());
+}
+
+inline void modenaModel::inputs_set(const size_t i, double x) const
+{
+    modena_inputs_set(inputs_, i, x);
+}
+
+inline double modenaModel::inputs_get(const size_t i) const
+{
+    return modena_inputs_get(inputs_, i);
+}
+
+inline double modenaModel::outputs_get(const size_t i) const
+{
+    return modena_outputs_get(outputs_, i);
+}
+
+inline void modenaModel::argPos_check() const
+{
+    modena_model_argPos_check(model_);
+}
+
+inline std::vector<std::string> modenaModel::inputs_names() const
+{
+    std::vector<std::string> v;
+
+    const char** iNames = modena_model_inputs_names(model_);
+    //char** iNames = modena_model_inputs_names(model_);
+    for(size_t i=0; i<modena_model_inputs_size(model_); i++)
+        v.push_back(std::string(iNames[i]));
+
+    return v;
+}
+
+inline std::vector<std::string> modenaModel::outputs_names() const
+{
+    std::vector<std::string> v;
+
+    const char** oNames = modena_model_outputs_names(model_);
+    // char** oNames = modena_model_outputs_names(model_);
+    for(size_t i=0; i<modena_model_outputs_size(model_); i++)
+        v.push_back(std::string(oNames[i]));
+
+    return v;
+}
+
+inline std::vector<std::string> modenaModel::parameters_names() const
+{
+    std::vector<std::string> v;
+
+    const char** pNames = modena_model_parameters_names(model_);
+    // char** pNames = modena_model_parameters_names(model_);
+    for(size_t i=0; i<modena_model_parameters_size(model_); i++)
+        v.push_back(std::string(pNames[i]));
+
+    return v;
+}
+
+inline void modenaModel::call() const
+{
+    modena_model_call(model_, inputs_, outputs_);
+
+    if(modena_error_occurred())
+        throw modenaException(modena_error());
+}
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
 
 } // End namespace Modena
 


### PR DESCRIPTION
Bumping CMake version to 3.0, which has several convenience improvements over 2.8, as well as enforcing out-of-source build. Fixed type conversion error in the C++ wrapper, input/output/parameter names are now of type "const char**", not "char**". Edited examples to comply with the changes.