### PR TITLE
Add files via upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:16.04
+
+WORKDIR /app
+RUN apt-get update && apt-get install -y automake libltdl-dev libltdl7 mongodb  python-pip python-scipy python-rpy2 python-blessings r-base r-base-dev build-essential swig cmake
+
+COPY . .
+RUN pip install -r requirements.txt
+RUN cd src && \
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=/app/MoDeNa . \
+  && make \
+  && make install
+  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+blessings==1.6
+decorator==4.0.6
+mongoengine==0.14.3
+numpy==1.11.0
+Pillow==3.1.2
+pymongo==3.0
+rpy2==2.7.8
+scipy==0.17.0
+scour==0.32
+singledispatch==3.4.0.3
+six==1.10.0


### PR DESCRIPTION
Added dockerfile and requirements to build MoDeNa on legacy OS.

Build MoDeNa image by executing: 
`docker build -t modena .`

Test the dockerized MoDeNa by executing:
`docker run -it --rm modena /app/MoDeNa/bin/twoTanksFullProblem`